### PR TITLE
Fanout exchange

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - name: Checkout

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -8,36 +8,51 @@ from ._message import Message, MessageStatus, QueuedMessage
 class Storage:
     def __init__(self) -> None:
         self._exchanges: Dict[str, List[Message]] = {}
+        self._exchange_types: Dict[str, str] = {}
         self._queues: Dict[str, Queue[Message]] = {}
         self._history: Dict[str, QueuedMessage] = OrderedDict()
         self._binds: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
 
     async def clear(self) -> None:
         self._exchanges = {}
+        self._exchange_types = {}
         self._queues = {}
         self._history = OrderedDict()
         self._binds = defaultdict(dict)
 
     async def add_message_to_exchange(self, exchange: str, message: Message) -> None:
-        if exchange not in self._exchanges:
-            self._exchanges[exchange] = []
+        await self.declare_exchange(exchange)
         self._exchanges[exchange].insert(0, message)
 
+        exchange_type = self._exchange_types[exchange]
         binds = self._binds.get(exchange)
-        routing_key = message.routing_key
 
-        if binds and routing_key in binds:
-            await self.add_message_to_queue(binds[routing_key], message)
+        if binds:
+            if exchange_type == "direct":
+                routing_key = message.routing_key
+
+                if routing_key in binds:
+                    await self.add_message_to_queue(binds[routing_key], message)
+            elif exchange_type == "fanout":
+                for queue in binds.values():
+                    await self.add_message_to_queue(queue, message)
+            else:
+                raise RuntimeError(f"{exchange_type} exchanges not supported")
 
     async def bind_queue_to_exchange(self, queue: str, exchange: str,
                                      routing_key: str = "") -> None:
+        await self.declare_queue(queue)
         self._binds[exchange][routing_key] = queue
+
+    async def declare_exchange(self, exchange: str, exchange_type: str = "direct") -> None:
+        if exchange not in self._exchanges:
+            self._exchanges[exchange] = []
+            self._exchange_types[exchange] = exchange_type
 
     async def declare_queue(self, queue: str) -> None:
         if queue not in self._queues:
             self._queues[queue] = Queue()
-
-        await self.bind_queue_to_exchange(queue, "", routing_key=queue)
+            await self.bind_queue_to_exchange(queue, "", routing_key=queue)
 
     async def get_messages_from_exchange(self, exchange: str) -> List[Message]:
         if exchange not in self._exchanges:

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -1,6 +1,6 @@
 from asyncio import Queue
-from collections import OrderedDict, defaultdict
-from typing import AsyncGenerator, DefaultDict, Dict, List
+from collections import defaultdict
+from typing import AsyncGenerator, DefaultDict, Dict, List, Tuple
 
 from ._message import Message, MessageStatus, QueuedMessage
 
@@ -10,14 +10,14 @@ class Storage:
         self._exchanges: Dict[str, List[Message]] = {}
         self._exchange_types: Dict[str, str] = {}
         self._queues: Dict[str, Queue[Message]] = {}
-        self._history: Dict[str, QueuedMessage] = OrderedDict()
+        self._history: List[Tuple[str, QueuedMessage]] = []
         self._binds: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
 
     async def clear(self) -> None:
         self._exchanges = {}
         self._exchange_types = {}
         self._queues = {}
-        self._history = OrderedDict()
+        self._history = []
         self._binds = defaultdict(dict)
 
     async def add_message_to_exchange(self, exchange: str, message: Message) -> None:
@@ -66,13 +66,15 @@ class Storage:
     async def add_message_to_queue(self, queue: str, message: Message) -> None:
         await self.declare_queue(queue)
         await self._queues[queue].put(message)
-        self._history[message.id] = QueuedMessage(message, queue)
+        self._history.append((message.id, QueuedMessage(message, queue)))
 
     async def get_history(self) -> List[QueuedMessage]:
-        return [message for message in self._history.values()][::-1]
+        return [message[1] for message in self._history[::-1]]
 
     async def change_message_status(self, message_id: str, status: MessageStatus) -> None:
-        self._history[message_id].set_status(status)
+        for msg_id, message in self._history:
+            if msg_id == message_id:
+                message.set_status(status)
 
     async def get_next_message(self, queue: str) -> AsyncGenerator[Message, None]:
         if queue not in self._queues:

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -1,5 +1,5 @@
 from asyncio import Queue
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from typing import AsyncGenerator, DefaultDict, Dict, List
 
 from ._message import Message, MessageStatus, QueuedMessage

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -1,5 +1,5 @@
 from asyncio import Queue
-from collections import OrderedDict, defaultdict
+from collections import defaultdict, OrderedDict
 from typing import AsyncGenerator, DefaultDict, Dict, List
 
 from ._message import Message, MessageStatus, QueuedMessage

--- a/amqp_mock/_storage.py
+++ b/amqp_mock/_storage.py
@@ -52,7 +52,7 @@ class Storage:
     async def declare_queue(self, queue: str) -> None:
         if queue not in self._queues:
             self._queues[queue] = Queue()
-            await self.bind_queue_to_exchange(queue, "", routing_key=queue)
+            await self.bind_queue_to_exchange(queue, exchange="", routing_key=queue)
 
     async def get_messages_from_exchange(self, exchange: str) -> List[Message]:
         if exchange not in self._exchanges:

--- a/amqp_mock/amqp_server/_amqp_connection.py
+++ b/amqp_mock/amqp_server/_amqp_connection.py
@@ -35,6 +35,7 @@ class AmqpConnection:
         self._delivery_tag = 0
         self._on_consume = on_consume
         self._on_bind: Optional[Callable[[str, str, str], Awaitable[None]]] = None
+        self._on_declare_exchange: Optional[Callable[[str, str], Awaitable[None]]] = None
         self._on_declare_queue: Optional[Callable[[str], Awaitable[None]]] = None
         self._on_publish: Optional[Callable[[Message], Awaitable[None]]] = None
         self._on_ack: Optional[Callable[[str], Awaitable[None]]] = None
@@ -43,6 +44,11 @@ class AmqpConnection:
 
     def on_bind(self, callback: Callable[[str, str, str], Awaitable[None]]) -> 'AmqpConnection':
         self._on_bind = callback
+        return self
+
+    def on_declare_exchange(self, callback: Callable[[str, str],
+                                                     Awaitable[None]]) -> 'AmqpConnection':
+        self._on_declare_exchange = callback
         return self
 
     def on_declare_queue(self, callback: Callable[[str], Awaitable[None]]) -> 'AmqpConnection':
@@ -229,6 +235,8 @@ class AmqpConnection:
 
     async def _send_exchange_declare_ok(self, channel_id: int,
                                         frame_in: commands.Exchange.Declare) -> None:
+        if self._on_declare_exchange:
+            await self._on_declare_exchange(frame_in.exchange, frame_in.exchange_type)
         frame_out = commands.Exchange.DeclareOk()
         return await self._send_frame(channel_id, frame_out)
 

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -51,10 +51,10 @@ class AmqpServer:
     async def _on_bind(self, queue: str, exchange: str, routing_key: str) -> None:
         await self._storage.bind_queue_to_exchange(queue, exchange, routing_key)
 
-    async def _on_declare_exchange(self, exchange: str, exchange_type: str):
+    async def _on_declare_exchange(self, exchange: str, exchange_type: str) -> None:
         await self._storage.declare_exchange(exchange, exchange_type)
 
-    async def _on_declare_queue(self, queue: str):
+    async def _on_declare_queue(self, queue: str) -> None:
         await self._storage.declare_queue(queue)
 
     async def _on_publish(self, message: Message) -> None:

--- a/amqp_mock/amqp_server/_amqp_server.py
+++ b/amqp_mock/amqp_server/_amqp_server.py
@@ -51,7 +51,10 @@ class AmqpServer:
     async def _on_bind(self, queue: str, exchange: str, routing_key: str) -> None:
         await self._storage.bind_queue_to_exchange(queue, exchange, routing_key)
 
-    async def _on_declare_queue(self, queue: str) -> None:
+    async def _on_declare_exchange(self, exchange: str, exchange_type: str):
+        await self._storage.declare_exchange(exchange, exchange_type)
+
+    async def _on_declare_queue(self, queue: str):
         await self._storage.declare_queue(queue)
 
     async def _on_publish(self, message: Message) -> None:
@@ -79,6 +82,7 @@ class AmqpServer:
         connection = AmqpConnection(reader, writer, self._on_consume, self._server_properties)
         connection.on_publish(self._on_publish) \
                   .on_bind(self._on_bind) \
+                  .on_declare_exchange(self._on_declare_exchange) \
                   .on_declare_queue(self._on_declare_queue) \
                   .on_ack(self._on_ack) \
                   .on_nack(self._on_nack) \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ pytest-asyncio==0.21.1
 pytest-cov==4.1.0
 pytest==7.4.0
 rtry==1.5.0
+d42==1.7.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Nikita Tsvetkov",
     author_email="tsv1@fastmail.com",
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     url="https://github.com/tsv1/amqp-mock",
     license="Apache-2.0",
     packages=find_packages(exclude=("tests",)),
@@ -28,7 +28,6 @@ setup(
     tests_require=find_dev_required(),
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tests/_test_utils/amqp_client.py
+++ b/tests/_test_utils/amqp_client.py
@@ -38,8 +38,9 @@ class AmqpClient:
         res = await self._channel.queue_declare(queue_name)
         assert isinstance(res, commands.Queue.DeclareOk)
 
-    async def queue_bind(self, queue_name: str, exchange_name: str) -> None:
-        res = await self._channel.queue_bind(queue_name, exchange_name, routing_key="")
+    async def queue_bind(self, queue_name: str, exchange_name: str,
+                         routing_key: str = "") -> None:
+        res = await self._channel.queue_bind(queue_name, exchange_name, routing_key=routing_key)
         assert isinstance(res, commands.Queue.BindOk)
 
     async def publish(self, message: bytes, exchange_name: str, routing_key: str = "") -> None:

--- a/tests/_test_utils/helpers.py
+++ b/tests/_test_utils/helpers.py
@@ -1,6 +1,8 @@
 import json
-from typing import Any
+from typing import Any, Dict, List, Union
 from uuid import uuid4
+
+from amqp_mock import Message, QueuedMessage
 
 
 def to_binary(message: Any) -> bytes:
@@ -9,3 +11,10 @@ def to_binary(message: Any) -> bytes:
 
 def random_uuid() -> str:
     return str(uuid4())
+
+
+_MessageType = Union[QueuedMessage, Message]
+
+
+def to_dict(smth: List[_MessageType]) -> List[Dict[str, Any]]:
+    return [x.to_dict() for x in smth]

--- a/tests/_test_utils/schemas.py
+++ b/tests/_test_utils/schemas.py
@@ -1,0 +1,22 @@
+from d42 import schema
+
+from amqp_mock import MessageStatus
+
+MessageSchema = schema.dict({
+    "id": schema.str.len(1, ...),
+    "value": schema.any,
+    "exchange": schema.str,
+    "routing_key": schema.str,
+    "properties": schema.dict,
+})
+
+QueuedMessageSchema = schema.dict({
+    "message": MessageSchema,
+    "queue": schema.str,
+    "status": schema.any(
+        schema.str(MessageStatus.INIT),
+        schema.str(MessageStatus.CONSUMING),
+        schema.str(MessageStatus.ACKED),
+        schema.str(MessageStatus.NACKED),
+    ),
+})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+from district42.types import Schema
+from valera import Formatter, validate
+
+
+def pytest_assertrepr_compare(op, left, right):
+    if isinstance(right, Schema):
+        result = validate(right, left)
+        formatter = Formatter()
+        errors = ["- " + e.format(formatter) for e in result.get_errors()]
+        return ["valera.ValidationException"] + errors

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -118,45 +118,6 @@ async def test_publish_message_specific_queue(*, mock_server, mock_client, amqp_
 
 
 @pytest.mark.asyncio
-async def test_publish_to_default_exchange(*, mock_server, mock_client, amqp_client):
-    with given:
-        exchange = ""
-        queue = "test_queue"
-        message = {"value": "text"}
-
-    with when:
-        await amqp_client.declare_queue(queue)
-        await amqp_client.publish(to_binary(message), exchange, routing_key=queue)
-        await amqp_client.consume(queue)
-
-    with then:
-        messages = await amqp_client.wait_for(message_count=1)
-        assert len(messages) == 1
-        assert messages[0].body == to_binary(message)
-        messages = await mock_client.get_exchange_messages("")
-        assert len(messages) == 1
-        assert messages[0].value == message
-
-
-@pytest.mark.asyncio
-async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client):
-    with given:
-        exchange = "test_exchange"
-        queue = "test_queue"
-        message = {"value": "text"}
-
-    with when:
-        await amqp_client.queue_bind(queue, exchange)
-        await amqp_client.publish(to_binary(message), exchange)
-        await amqp_client.consume(queue)
-
-    with then:
-        messages = await amqp_client.wait_for(message_count=1)
-        assert len(messages) == 1
-        assert messages[0].body == to_binary(message)
-
-
-@pytest.mark.asyncio
 async def test_publish_to_fanout_exchange(*, mock_server, amqp_client):
     with given:
         exchange = "test_exchange"

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -143,16 +143,40 @@ async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client)
     with given:
         exchange = "test_exchange"
         queue = "test_queue"
-        message = b"text"
+        message = {"value": "text"}
 
     with when:
         await amqp_client.queue_bind(queue, exchange)
-        await amqp_client.publish(message, exchange)
+        await amqp_client.publish(to_binary(message), exchange)
         await amqp_client.consume(queue)
 
     with then:
         messages = await amqp_client.wait_for(message_count=1)
         assert len(messages) == 1
+        assert messages[0].body == to_binary(message)
+
+
+@pytest.mark.asyncio
+async def test_publish_to_fanout_exchange(*, mock_server, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue1, queue2 = "test_queue1", "test_queue2"
+        message = {"value": "text"}
+
+    with when:
+        await amqp_client.declare_exchange(exchange, "fanout")
+
+        for queue in [queue1, queue2]:
+            await amqp_client.queue_bind(queue, exchange, routing_key=queue)
+            await amqp_client.consume(queue)
+
+        await amqp_client.publish(to_binary(message), exchange)
+
+    with then:
+        messages = await amqp_client.wait_for(message_count=2)
+        assert len(messages) == 2
+        for message_ in messages:
+            assert message_.body == to_binary(message)
 
 
 @pytest.mark.asyncio

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -118,6 +118,27 @@ async def test_publish_message_specific_queue(*, mock_server, mock_client, amqp_
 
 
 @pytest.mark.asyncio
+async def test_publish_to_default_exchange(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = ""
+        queue = "test_queue"
+        message = {"value": "text"}
+
+    with when:
+        await amqp_client.declare_queue(queue)
+        await amqp_client.publish(to_binary(message), exchange, routing_key=queue)
+        await amqp_client.consume(queue)
+
+    with then:
+        messages = await amqp_client.wait_for(message_count=1)
+        assert len(messages) == 1
+        assert messages[0].body == to_binary(message)
+        messages = await mock_client.get_exchange_messages("")
+        assert len(messages) == 1
+        assert messages[0].value == message
+
+
+@pytest.mark.asyncio
 async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client):
     with given:
         exchange = "test_exchange"

--- a/tests/test_publish_message.py
+++ b/tests/test_publish_message.py
@@ -118,6 +118,23 @@ async def test_publish_message_specific_queue(*, mock_server, mock_client, amqp_
 
 
 @pytest.mark.asyncio
+async def test_publish_to_exchange_with_bound_queue(*, mock_server, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue = "test_queue"
+        message = b"text"
+
+    with when:
+        await amqp_client.queue_bind(queue, exchange)
+        await amqp_client.publish(message, exchange)
+        await amqp_client.consume(queue)
+
+    with then:
+        messages = await amqp_client.wait_for(message_count=1)
+        assert len(messages) == 1
+
+
+@pytest.mark.asyncio
 async def test_publish_no_messages(*, mock_server, amqp_client):
     with given:
         queue = "test_queue1"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -116,13 +116,14 @@ async def test_routing_fanout_exchange(*, mock_server, mock_client, amqp_client)
         exchange = "test_exchange"
         queue1, queue2 = "test_queue1", "test_queue2"
         message = {"id": random_uuid()}
+        routing_key = random_uuid()
 
         await amqp_client.declare_exchange(exchange, "fanout")
         for queue in [queue1, queue2]:
             await amqp_client.queue_bind(queue, exchange, routing_key=queue)
 
     with when:
-        await amqp_client.publish(to_binary(message), exchange)
+        await amqp_client.publish(to_binary(message), exchange, routing_key=routing_key)
 
     with then:
         history_queue1 = await mock_client.get_queue_message_history(queue1)
@@ -131,7 +132,7 @@ async def test_routing_fanout_exchange(*, mock_server, mock_client, amqp_client)
                 "message": {
                     "value": message,
                     "exchange": exchange,
-                    "routing_key": queue1,
+                    "routing_key": routing_key,
                 },
                 "queue": queue1,
                 "status": MessageStatus.INIT,
@@ -144,7 +145,7 @@ async def test_routing_fanout_exchange(*, mock_server, mock_client, amqp_client)
                 "message": {
                     "value": message,
                     "exchange": exchange,
-                    "routing_key": queue2,
+                    "routing_key": routing_key,
                 },
                 "queue": queue2,
                 "status": MessageStatus.INIT,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,152 @@
+import pytest
+from d42 import schema
+
+from amqp_mock import MessageStatus
+
+from ._test_utils.fixtures import amqp_client, mock_client, mock_server
+from ._test_utils.helpers import random_uuid, to_binary, to_dict
+from ._test_utils.schemas import MessageSchema, QueuedMessageSchema
+from ._test_utils.steps import given, then, when
+
+__all__ = ("mock_client", "mock_server", "amqp_client",)
+
+
+@pytest.mark.asyncio
+async def test_routing(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = ""
+        queue = "test_queue"
+        routing_key = ""
+        message = {"id": random_uuid()}
+
+        await amqp_client.declare_queue(queue)
+
+    with when:
+        await amqp_client.publish(to_binary(message), exchange, routing_key=routing_key)
+
+    with then:
+        history = await mock_client.get_queue_message_history(queue)
+        assert history == schema.list.len(0)
+
+        messages = await mock_client.get_exchange_messages(exchange)
+        assert to_dict(messages) == schema.list([
+            MessageSchema % {
+                "value": message,
+                "exchange": exchange,
+                "routing_key": routing_key,
+            }
+        ])
+
+
+@pytest.mark.asyncio
+async def test_routing_with_default_exchange(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = ""
+        queue = "test_queue"
+        message = {"id": random_uuid()}
+
+        await amqp_client.declare_queue(queue)
+
+    with when:
+        await amqp_client.publish(to_binary(message), exchange, routing_key=queue)
+
+    with then:
+        history = await mock_client.get_queue_message_history(queue)
+        assert to_dict(history) == schema.list([
+            QueuedMessageSchema % {
+                "message": {
+                    "value": message,
+                    "exchange": exchange,
+                    "routing_key": queue,
+                },
+                "queue": queue,
+                "status": MessageStatus.INIT,
+            }
+        ])
+
+
+@pytest.mark.asyncio
+async def test_routing_with_custom_exchange(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue = "test_queue"
+        message = {"id": random_uuid()}
+
+        await amqp_client.declare_queue(queue)
+
+    with when:
+        await amqp_client.publish(to_binary(message), exchange, routing_key=queue)
+
+    with then:
+        history = await mock_client.get_queue_message_history(queue)
+        assert history == schema.list.len(0)
+
+
+@pytest.mark.asyncio
+async def test_routing_with_bound_queue(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue = "test_queue"
+        message = {"id": random_uuid()}
+
+        await amqp_client.queue_bind(queue, exchange)
+
+    with when:
+        await amqp_client.publish(to_binary(message), exchange)
+
+    with then:
+        history = await mock_client.get_queue_message_history(queue)
+        assert to_dict(history) == schema.list([
+            QueuedMessageSchema % {
+                "message": {
+                    "value": message,
+                    "exchange": exchange,
+                    "routing_key": "",
+                },
+                "queue": queue,
+                "status": MessageStatus.INIT,
+            }
+        ])
+
+
+@pytest.mark.asyncio
+@pytest.mark.only
+async def test_routing_fanout_exchange(*, mock_server, mock_client, amqp_client):
+    with given:
+        exchange = "test_exchange"
+        queue1, queue2 = "test_queue1", "test_queue2"
+        message = {"id": random_uuid()}
+
+        await amqp_client.declare_exchange(exchange, "fanout")
+        for queue in [queue1, queue2]:
+            await amqp_client.queue_bind(queue, exchange, routing_key=queue)
+
+    with when:
+        await amqp_client.publish(to_binary(message), exchange)
+
+    with then:
+        history_queue1 = await mock_client.get_queue_message_history(queue1)
+        assert to_dict(history_queue1) == schema.list([
+            QueuedMessageSchema % {
+                "message": {
+                    "value": message,
+                    "exchange": exchange,
+                    "routing_key": queue1,
+                },
+                "queue": queue1,
+                "status": MessageStatus.INIT,
+            }
+        ])
+
+        history_queue2 = await mock_client.get_queue_message_history(queue2)
+        assert to_dict(history_queue2) == schema.list([
+            QueuedMessageSchema % {
+                "message": {
+                    "value": message,
+                    "exchange": exchange,
+                    "routing_key": queue2,
+                },
+                "queue": queue2,
+                "status": MessageStatus.INIT,
+            }
+        ])


### PR DESCRIPTION
Hi,
Great project.

In this PR I have rebased and fixed the changes that were introduced in these older ones:
https://github.com/tsv1/amqp-mock/pull/10
https://github.com/tsv1/amqp-mock/pull/23

I also changed `Storage._history` from `{msg_id: msg}` mapping to `[(msg_id, msg), ...]` list to better support multiple copies of messages by fanout exchanges since they have the same ID.

Thanks.